### PR TITLE
feat:  Add clang tidy support to CI

### DIFF
--- a/.circleci/clang_tidy.sh
+++ b/.circleci/clang_tidy.sh
@@ -1,0 +1,16 @@
+# run clang tidy
+cmake -DENABLE_CLANG_TIDY=ON .
+make tidy > output.txt
+#if [[ -n $(grep "warning: " output.txt) ]] || [[ -n $(grep "error: " output.txt) ]]; then
+# for now only fail the test on errors.  Change this as project matures
+if [[ -n $(grep "error: " output.txt) ]]; then
+    echo "You must pass the clang tidy checks before submitting a pull request"
+    echo ""
+    grep --color -E '^|warning: |error: ' output.txt
+    exit -1;
+else
+    # still output the file to show warnings
+    echo ""
+    grep --color -E '^|warning: |error: ' output.txt
+    echo -e "\033[1;32m\xE2\x9C\x93 passed:\033[0m $1";
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             sudo apt-add-repository -y ppa:george-edison55/cmake-3.x
             sudo apt-get update
             sudo apt install python-lldb-5.0 lcov cmake
-            sudo apt install clang-5.0 clang-5.0-doc libclang-common-5.0-dev libclang-5.0-dev libclang1-5.0 libllvm5.0 lldb-5.0 llvm-5.0 llvm-5.0-dev
+            sudo apt install clang-5.0 clang-tidy-5.0 clang-5.0-doc libclang-common-5.0-dev libclang-5.0-dev libclang1-5.0 libllvm5.0 lldb-5.0 llvm-5.0 llvm-5.0-dev
 
             sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-5.0 60
             sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 50
@@ -63,6 +63,11 @@ jobs:
       - run:
           name: Build
           command: ./.circleci/script_desktop.sh
+          
+      - run:
+          name: Clang Tidy
+          command: ./.circleci/clang_tidy.sh
+          
   build-macos-9-2:
     macos:
       xcode: "9.2.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(Ark-Cpp-Crypto)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR})
@@ -21,6 +22,37 @@ execute_process(
 	COMMAND git submodule update --init --recursive
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
+
+# ------------------------------------------------------------------------------
+# Clang Tidy
+# ------------------------------------------------------------------------------
+
+if(ENABLE_CLANG_TIDY)
+
+    find_program(CLANG_TIDY_BIN clang-tidy-5.0)
+    find_program(RUN_CLANG_TIDY_BIN run-clang-tidy-5.0.py)
+
+    if(CLANG_TIDY_BIN STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
+        message(FATAL_ERROR "unable to locate clang-tidy-5.0")
+    endif()
+
+   if(RUN_CLANG_TIDY_BIN STREQUAL "RUN_CLANG_TIDY_BIN-NOTFOUND")
+       message(FATAL_ERROR "unable to locate run-clang-tidy-5.0.py")
+   endif()
+
+    list(APPEND RUN_CLANG_TIDY_BIN_ARGS
+        -clang-tidy-binary ${CLANG_TIDY_BIN}
+        -header-filter=.*
+        -checks=clan*,cert*,misc*,perf*,cppc*,read*,mode*,-cert-err58-cpp,-misc-noexcept-move-constructor
+    )
+
+    add_custom_target(
+        tidy
+        COMMAND ${RUN_CLANG_TIDY_BIN} ${RUN_CLANG_TIDY_BIN_ARGS}
+        COMMENT "running clang tidy"
+    )
+
+endif()
 
 add_subdirectory(src)
 add_subdirectory(test)


### PR DESCRIPTION
## Proposed changes
Added clang tidy support to the clang CI target.  As a first step warnings will not fail the build.  Once we are down to 0 warnings, we can make warnings fail the build.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] New feature (non-breaking change which adds functionality)
- [X] Build (changes that affect the build system)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes

## Further comments
N/A
