### PR TITLE
fix:  Correct PIO builds

### DIFF
--- a/.circleci/install_platform_io.sh
+++ b/.circleci/install_platform_io.sh
@@ -4,8 +4,5 @@ sudo pip install -U platformio
 # update PlatformIO
 platformio update
 
-# install AUnit (2778) micro-ecc (1665) bip39 (5886) libraries
-platformio lib -g install 2778 1665 5886
-
 # ensure all git submodules have bee clone
 git submodule update --init --recursive

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 description = "A simple Cryptography Implementation in C++ for the ARK Blockchain."
 
 [common]
-lib_deps = micro-ecc, bip39
+lib_deps = micro-ecc, bip39@^1.1
 build_flags = -I./src/ -I./src/bcl -I./src/include/cpp-crypto
 src_filter = +<*> -<.git/> -<examples/> -<lib> -<CMakeFiles>
 upload_speed = 921600

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,7 @@
 description = "A simple Cryptography Implementation in C++ for the ARK Blockchain."
 
 [common]
+lib_ldf_mode = off
 lib_deps = micro-ecc, bip39@^1.1
 build_flags = -I./src/ -I./src/bcl -I./src/include/cpp-crypto
 src_filter = +<*> -<.git/> -<examples/> -<lib> -<CMakeFiles>
@@ -21,6 +22,7 @@ upload_speed = 921600
 platform = espressif8266
 board = huzzah
 framework = arduino
+lib_ldf_mode = ${common.lib_ldf_mode}
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter}
@@ -30,6 +32,7 @@ upload_speed = ${common.upload_speed}
 platform = espressif32
 board = esp32dev
 framework = arduino
+lib_ldf_mode = ${common.lib_ldf_mode}
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter}

--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -14,15 +14,17 @@ src_dir = ..
 lib_dir = ..
 
 [common]
+lib_ldf_mode = off
 lib_deps = micro-ecc, bip39@^1.1, AUnit
 build_flags = -I../test/iot/ -I../src -I../src/bcl -I../src/include/cpp-crypto -DUNIT_TEST
-src_filter = +<*> -<.git/> -<examples/> -<bin> -<lib> -<_3rdParty> -<CMakeFiles> -<src/CMakeFiles> -<test/CMakeFiles> -<src/lib> -<test/lib/googletest>
+src_filter = +<*> -<.git/> -<examples/> -<extras> -<bin> -<lib> -<_3rdParty> -<CMakeFiles> -<src/CMakeFiles> -<test/CMakeFiles> -<src/lib> -<test/lib/googletest>
 upload_speed = 921600
 
 [env:esp8266]
 platform = espressif8266
 board = huzzah
 framework = arduino
+lib_ldf_mode = ${common.lib_ldf_mode}
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter}
@@ -32,6 +34,7 @@ upload_speed = ${common.upload_speed}
 platform = espressif32
 board = esp32dev
 framework = arduino
+lib_ldf_mode = ${common.lib_ldf_mode}
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter}

--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -14,7 +14,7 @@ src_dir = ..
 lib_dir = ..
 
 [common]
-lib_deps = micro-ecc, bip39, AUnit
+lib_deps = micro-ecc, bip39@^1.1, AUnit
 build_flags = -I../test/iot/ -I../src -I../src/bcl -I../src/include/cpp-crypto -DUNIT_TEST
 src_filter = +<*> -<.git/> -<examples/> -<bin> -<lib> -<_3rdParty> -<CMakeFiles> -<src/CMakeFiles> -<test/CMakeFiles> -<src/lib> -<test/lib/googletest>
 upload_speed = 921600


### PR DESCRIPTION
## Proposed changes
Updated BIP39 submodule and PIO configs to be more explicit in determining dependencies.  This allows for more control and better determinism as to what PIO will actually compile into the project.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Build (changes that affect the build system)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes

## Further comments
This should fix the current build issues in the open PRs.