### PR TITLE
Fix PIO CI Builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ description = "A simple Cryptography Implementation in C++ for the ARK Blockchai
 lib_ldf_mode = off
 lib_deps = micro-ecc, bip39@^1.1, ArduinoJson
 build_flags = -I./src/ -I./src/lib -I./src/include/cpp-crypto
-src_filter = +<*> -<.git/> -<examples/> -<src/lib/ArduinoJson> -<src/lib/bip39> -<src/lib/uECC> -<CMakeFiles>
+src_filter = +<*> -<.git/> -<examples/> -<lib/ArduinoJson> -<lib/bip39> -<lib/uECC> -<CMakeFiles>
 upload_speed = 921600
 
 [env:esp8266]


### PR DESCRIPTION
## Proposed changes
This change fixes the currently broken PIO CI builds by correcting the submodules ignore paths in the PIO INI file.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Build (changes that affect the build system)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [X] Lint and unit tests pass locally with my changes

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
N/A