### PR TITLE
fix: improve Windows support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- improved Windows support ([#83])
+
 ## [0.3.1] - 2019-02-19
 
 ### Fixed

--- a/src/transactions/transaction.cpp
+++ b/src/transactions/transaction.cpp
@@ -234,7 +234,8 @@ std::map<std::string, std::string> Ark::Crypto::Transactions::Transaction::toArr
 std::string Ark::Crypto::Transactions::Transaction::toJson() {
   std::map<std::string, std::string> txArray = this->toArray();
 
-  DynamicJsonDocument doc(900);
+  const size_t docCapacity = 900;
+  DynamicJsonDocument doc(docCapacity);
 
   //  Amount
   doc["amount"] = txArray["amount"];
@@ -337,8 +338,8 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
     doc["version"] = txArray["version"];
   }
 
-  char jsonChar[measureJson(doc) + 1];
-  serializeJson(doc, jsonChar, measureJson(doc) + 1);
+  char jsonChar[docCapacity];
+  serializeJson(doc, jsonChar, docCapacity);
 
   return jsonChar;
 }

--- a/src/utils/message.cpp
+++ b/src/utils/message.cpp
@@ -92,16 +92,22 @@ std::map<std::string, std::string> Ark::Crypto::Utils::Message::toArray() {
 std::string Ark::Crypto::Utils::Message::toJson() {
   std::map<std::string, std::string> messageArray = this->toArray();
 
-  // const size_t capacity = JSON_OBJECT_SIZE(3);
-  DynamicJsonDocument doc(400);
+  const size_t docLength
+      = (33 + 1)  // publickey length
+      + (72 + 1)  // signature length
+      + this->message.length();
+  const size_t docCapacity = JSON_OBJECT_SIZE(3) + docLength + 120;
+
+  DynamicJsonDocument doc(docCapacity);
 
   doc["publickey"] = messageArray["publickey"];
   doc["signature"] = messageArray["signature"];
   doc["message"] = messageArray["message"];
 
-  char jsonChar[measureJson(doc) + 1];
-  serializeJson(doc, jsonChar, measureJson(doc) + 1);
+  std::string jsonStr;
+  jsonStr.reserve(docCapacity);
+  serializeJson(doc, &jsonStr[0], docCapacity);
 
-  return jsonChar;
+  return jsonStr;
 }
 /**/


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Current Windows builds fail with the following:
`error C2131: expression did not evaluate to a constant`
> example build log can be found here: [FAILING: ci.appveyor/sleepdefic1t/cpp-crypto](https://ci.appveyor.com/project/sleepdefic1t/cpp-crypto/builds/24682089/job/kx9dyho0p961m0sf)

This is due to the way Windows handles dynamic allocation.
The current implementation uses this breaking allocation pattern in `transaction.cpp` and `message.cpp`.

After the changes in this PR, Windows builds pass.
> example build log can be found here: [PASSING: ci.appveyor/sleepdefic1t/cpp-crypto](https://ci.appveyor.com/project/sleepdefic1t/cpp-crypto/builds/24682137/job/5b40uk1h4pat3x00)

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

A later PR will address adding Appveyor support.