### PR TITLE
feat: Increase VendorField Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-
 ## [0.4.0] - 2019-05-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
 ## [0.4.0] - 2019-05-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+
+## [0.4.0] - 2019-05-20
+
+### Changed
+
+- updated vendorField to support 255 bytes in Core v2.4 ([#84])
+- updated ArduinoJson package to version v.6.10.0 ([#76])
+- updated tests to use Core fixtures ([#74])
+
 ## [0.3.1] - 2019-02-19
 
 ### Fixed

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/ArkEcosystem/Cpp-Crypto.git"
   },
-  "version": "0.3.1",
+  "version": "0.4.0",
   "authors": [
     {
       "name": "Ark Ecosystem",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Ark-Cpp-Crypto
-version=0.3.1
+version=0.4.0
 author=Ark Ecosystem
 maintainer=Ark Ecosystem
 sentence=A simple Cryptography Implementation in C++ for the ARK Blockchain.

--- a/src/transactions/transaction.cpp
+++ b/src/transactions/transaction.cpp
@@ -87,7 +87,7 @@ std::vector<uint8_t> Ark::Crypto::Transactions::Transaction::toBytes(
     bytes.insert(std::end(bytes), std::begin(filler), std::end(filler));
   }
 
-  if (!this->vendorField.empty()) {
+  if (!this->vendorField.empty() && vendorField.length() <= 255) {
     bytes.insert(std::end(bytes), std::begin(this->vendorField), std::end(this->vendorField));
 
     size_t diff = 64 - vendorField.length();
@@ -95,7 +95,6 @@ std::vector<uint8_t> Ark::Crypto::Transactions::Transaction::toBytes(
       std::vector<uint8_t> filler(diff, 0);
       bytes.insert(std::end(bytes), std::begin(filler), std::end(filler));
     }
-
   } else {
     std::vector<uint8_t> filler(64, 0);
     bytes.insert(std::end(bytes), std::begin(filler), std::end(filler));


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This PR supports the change in vendorField size from 64 bytes to 255 bytes in Core v2.4.

Specifically:
- `transaction.cpp`: update vendorField handling.
- minor version bump
- makes changelog current as of master + changes.

This also addresses #82 

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
