### PR TITLE
fix: 0 ARKtoshi amount handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- properly handle 0 ARKtoshi Transaction amounts.
+
 ## [0.3.1] - 2019-02-19
 
 ### Fixed

--- a/src/include/cpp-crypto/transactions/builder.h
+++ b/src/include/cpp-crypto/transactions/builder.h
@@ -18,8 +18,17 @@ namespace Transactions {
 
 class Builder {
  public:
+  /**
+  * Builder::buildTransfer()
+  *
+  * note: The 'Type 0'/Transfer amount must be greater than 0 ARKtoshi.
+  * If amount is not > 0, Builder will return an empty Transaction object and
+  * validation will fail.
+  **/
   static Transaction buildTransfer(std::string recipientId, uint64_t amount, std::string vendorField,
                                    std::string passphrase, std::string secondPassphrase = "");
+  /**/
+
   static Transaction buildSecondSignatureRegistration(std::string passphrase, std::string secondPassphrase = "");
   static Transaction buildDelegateRegistration(std::string username, std::string passphrase,
                                                std::string secondPassphrase = "");

--- a/src/transactions/builder.cpp
+++ b/src/transactions/builder.cpp
@@ -13,6 +13,8 @@ namespace Transactions {
 Transaction Builder::buildTransfer(std::string recipientId, uint64_t amount, std::string vendorField,
                                    std::string passphrase, std::string secondPassphrase) {
   Transaction transaction;
+  if (amount < 1ull) { return transaction; };
+
   transaction.type = Enums::Types::TRANSFER;
   transaction.fee = Configuration::Fee().get(Enums::Types::TRANSFER);
   transaction.recipientId = std::move(recipientId);

--- a/src/transactions/transaction.cpp
+++ b/src/transactions/transaction.cpp
@@ -58,6 +58,8 @@ bool Ark::Crypto::Transactions::Transaction::internalVerify(
     std::string publicKey,
     std::vector<uint8_t> bytes,
     std::string signature) const {
+  if (bytes.empty()) { return false; };
+
   const auto hash = Sha256::getHash(&bytes[0], bytes.size());
   const auto key = Identities::PublicKey::fromHex(publicKey.c_str());
   auto signatureBytes = HexToBytes(signature.c_str());
@@ -68,6 +70,8 @@ std::vector<uint8_t> Ark::Crypto::Transactions::Transaction::toBytes(
     bool skipSignature,
     bool skipSecondSignature) const {
   std::vector<uint8_t> bytes;
+
+  if (this->type == 0 && amount < 1ull) { return bytes; };
 
   pack(bytes, this->type);
   pack(bytes, this->timestamp);

--- a/test/transactions/builder.cpp
+++ b/test/transactions/builder.cpp
@@ -13,4 +13,14 @@ TEST(transactions, build_transfer) {
   ASSERT_STREQ("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib", actual.recipientId.c_str());
   ASSERT_TRUE(100000000 == actual.amount);
   ASSERT_STREQ("", actual.vendorField.c_str());
+
+  // test 0 ARKtoshi value
+  const auto shouldBeEmpty = Ark::Crypto::Transactions::Builder::buildTransfer(
+      "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
+      0,
+      "",
+      "Secret passphrase");
+  ASSERT_STREQ("", shouldBeEmpty.recipientId.c_str());
+  ASSERT_EQ(0, shouldBeEmpty.amount);
+  ASSERT_FALSE(shouldBeEmpty.verify());
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This PR addresses #79 and adds additional checking to ensure that a 'Type-0'/Transfer Transaction amount is greater than 0 ARKtoshi. 

This PR:
- returns empty/unvalidatable transaction if Transfer-type amount is not > 0.
- adds comments about > 0 ARKtoshi to Transaction::buildTransfer declaration.
- adds test for 0 ARKtoshi amount on Type-0 tx's.

note: 0 is already default amount for Transactions, no additional changes were needed.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
