### PR TITLE
misc: Disable PlatformIO ESP8266 Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- disable ESP8266 PlatformIO test builds
+
 ## [0.3.1] - 2019-02-19
 
 ### Fixed

--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -20,15 +20,16 @@ build_flags = -I../test/iot/ -I../src -I../src/lib -I../src/include/cpp-crypto -
 src_filter = +<*> -<.git/> -<examples/> -<extras> -<bin> -<lib> -<_3rdParty> -<CMakeFiles> -<src/CMakeFiles> -<test/CMakeFiles> -<src/lib/ArduinoJson> -<src/lib/bip39> -<src/lib/uECC> -<test/lib/googletest>
 upload_speed = 921600
 
-[env:esp8266]
-platform = espressif8266
-board = huzzah
-framework = arduino
-lib_ldf_mode = ${common.lib_ldf_mode}
-lib_deps = ${common.lib_deps}
-build_flags = ${common.build_flags}
-src_filter = ${common.src_filter}
-upload_speed = ${common.upload_speed}
+# esp8266 unit tests disabled until support is worked out
+#[env:esp8266]
+#platform = espressif8266
+#board = huzzah
+#framework = arduino
+#lib_ldf_mode = ${common.lib_ldf_mode}
+#lib_deps = ${common.lib_deps}
+#build_flags = ${common.build_flags}
+#src_filter = ${common.src_filter}
+#upload_speed = ${common.upload_speed}
 
 [env:esp32]
 platform = espressif32


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

AUnit has stopped correctly building tests for the partially-supported ESP8266 platform on Linux platforms.
It seems this may be a change in either PIO, AUnit, or ESP8266 Core; so this PR disables ESP8266 tests in PlatformIO until support is worked out.

This points PIO CI testing to the fully supported ESP32 platform instead.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Other... Please describe:

Disables ESP8266 test building on PlatformIO

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
