### PR TITLE
chore: use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,33 +6,33 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Ark KEYWORD1
-Crypto  KEYWORD1
-Configuration   KEYWORD1
-Enums   KEYWORD1
-Identities  KEYWORD1
-Networks    KEYWORD1
-Transactions    KEYWORD1
-Utils   KEYWORD1
+Ark	KEYWORD1
+Crypto	KEYWORD1
+Configuration	KEYWORD1
+Enums	KEYWORD1
+Identities	KEYWORD1
+Networks	KEYWORD1
+Transactions	KEYWORD1
+Utils	KEYWORD1
 
-Fee KEYWORD1
-Network KEYWORD1
+Fee	KEYWORD1
+Network	KEYWORD1
 
-Fees    KEYWORD1
-Types   KEYWORD1
+Fees	KEYWORD1
+Types	KEYWORD1
 
-Address KEYWORD1
-PrivateKey  KEYWORD1
-PublicKey   KEYWORD1
-WIF KEYWORD1
+Address	KEYWORD1
+PrivateKey	KEYWORD1
+PublicKey	KEYWORD1
+WIF	KEYWORD1
 
-Builder KEYWORD1
-Deserializer    KEYWORD1
-Serializer  KEYWORD1
-Transaction KEYWORD1
+Builder	KEYWORD1
+Deserializer	KEYWORD1
+Serializer	KEYWORD1
+Transaction	KEYWORD1
 
-Message KEYWORD1
-Slot    KEYWORD1
+Message	KEYWORD1
+Slot	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -42,6 +42,6 @@ Slot    KEYWORD1
 # Constants (LITERAL1)
 #######################################
 
-Devnet  LITERAL1
-Mainnet LITERAL1
-Testnet LITERAL1
+Devnet	LITERAL1
+Mainnet	LITERAL1
+Testnet	LITERAL1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords
<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [NA] All tests are passing
- [NA] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [NA] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
