### PR TITLE
test(networks): Fix AbstractNetwork Tests

### DIFF
--- a/test/networks/abstractnetwork.cpp
+++ b/test/networks/abstractnetwork.cpp
@@ -59,14 +59,16 @@ TEST(networks, abstract_network_base58_prefix_get) {
 /**/
 
 TEST(networks, abstract_network_base58_prefix_set) {
-  CUSTOM_NETWORK.setBase58Prefix(BASE58_ADDRESS_P2PKH, 0x10);
-  ASSERT_EQ(0x10, CUSTOM_NETWORK.getBase58Prefix(BASE58_ADDRESS_P2PKH));
+  AbstractNetwork testNetwork = CUSTOM_NETWORK;
 
-  CUSTOM_NETWORK.setBase58Prefix(BASE58_ADDRESS_P2SH, 0x20);
-  ASSERT_EQ(0x20, CUSTOM_NETWORK.getBase58Prefix(BASE58_ADDRESS_P2SH));
+  testNetwork.setBase58Prefix(BASE58_ADDRESS_P2PKH, 0x10);
+  ASSERT_EQ(0x10, testNetwork.getBase58Prefix(BASE58_ADDRESS_P2PKH));
 
-  CUSTOM_NETWORK.setBase58Prefix(BASE58_WIF, 0x30);
-  ASSERT_EQ(0x30, CUSTOM_NETWORK.getBase58Prefix(BASE58_WIF));
+  testNetwork.setBase58Prefix(BASE58_ADDRESS_P2SH, 0x20);
+  ASSERT_EQ(0x20, testNetwork.getBase58Prefix(BASE58_ADDRESS_P2SH));
+
+  testNetwork.setBase58Prefix(BASE58_WIF, 0x30);
+  ASSERT_EQ(0x30, testNetwork.getBase58Prefix(BASE58_WIF));
 }
 
 /**/
@@ -79,11 +81,13 @@ TEST(networks, abstract_network_bip32_prefix_get) {
 /**/
 
 TEST(networks, abstract_network_bip32_prefix_set) {
-  CUSTOM_NETWORK.setBIP32Prefix(BIP32_PREFIX_XPUB, 1000000);
-  ASSERT_EQ(1000000, CUSTOM_NETWORK.getBIP32Prefix(BIP32_PREFIX_XPUB));
+  AbstractNetwork testNetwork = CUSTOM_NETWORK;
 
-  CUSTOM_NETWORK.setBIP32Prefix(BIP32_PREFIX_XPRV, 1000001);
-  ASSERT_EQ(1000001, CUSTOM_NETWORK.getBIP32Prefix(BIP32_PREFIX_XPRV));
+  testNetwork.setBIP32Prefix(BIP32_PREFIX_XPUB, 1000000);
+  ASSERT_EQ(1000000, testNetwork.getBIP32Prefix(BIP32_PREFIX_XPUB));
+
+  testNetwork.setBIP32Prefix(BIP32_PREFIX_XPRV, 1000001);
+  ASSERT_EQ(1000001, testNetwork.getBIP32Prefix(BIP32_PREFIX_XPRV));
 }
 
 /**/


### PR DESCRIPTION
Current tests are ran in different orders per platform.
This led to a global test custom_network (AbstractNetwork) being modified incorrectly.

This PR properly handles that order variation by creating a local object to be modified instead.

Tests may fail until #101 is merged and this PR is rebased.

## What kind of change does this PR introduce?

- [x] Tests

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included
