### PR TITLE
fix(transaction): Improve Numeric Json Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - improved formatting and maintainability ([#98])
 - improved Slots implementations ([#92])
 
+### Fixed
+
+- fixed Transaction Json numeric serialization ([#103])
+
 ## [0.5.0] - 2019-02-20
 
 ### Changed

--- a/src/helpers/crypto_helpers.h
+++ b/src/helpers/crypto_helpers.h
@@ -29,6 +29,13 @@ const auto WIF_SIZE = 52U;
 
 #endif
 
+#ifndef USE_IOT
+
+#define __STDC_FORMAT_MACROS 1
+#include <cinttypes>
+
+#endif
+
 // Write data into dst
 template <typename T>
 inline void pack(std::vector<uint8_t>& dst, T& data) {

--- a/src/transactions/transaction.cpp
+++ b/src/transactions/transaction.cpp
@@ -12,12 +12,10 @@
 
 #include "bcl/Sha256.hpp"
 
+#include <cstdlib>
 #include <map>
 #include <string>
 #include <vector>
-
-#define __STDC_FORMAT_MACROS 1
-#include <cinttypes>
 
 using namespace Ark::Crypto::Identities;
 
@@ -326,7 +324,7 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
   DynamicJsonDocument doc(docCapacity);
 
   //  Amount
-  doc["amount"] = txArray["amount"];
+  doc["amount"] = strtoull(txArray["amount"].c_str(), nullptr, 10);
 
   //  Asset
   if (this->type == 0) {
@@ -342,7 +340,7 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
     JsonObject dAsset = doc.createNestedObject("asset");
     JsonObject delegate = dAsset.createNestedObject("delegate");
     delegate["username"] = txArray["username"];
-  }else if (this->type == 3) {
+  } else if (this->type == 3) {
     //  Vote
     JsonObject vAsset = doc.createNestedObject("asset");
     JsonArray votes = vAsset.createNestedArray("votes");
@@ -368,14 +366,14 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
   };
 
   //  Fee
-  doc["fee"] = txArray["fee"];
+  doc["fee"] = strtoull(txArray["fee"].c_str(), nullptr, 10);
 
   //  Id
   doc["id"] = txArray["id"];
 
   //  Network
   if (txArray["network"] != "0") {
-    doc["network"] = txArray["network"];
+    doc["network"] = atoi(txArray["network"].c_str());
   };
 
   //  RecipientId
@@ -410,10 +408,10 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
   };
 
   //  Timestamp
-  doc["timestamp"] = txArray["timestamp"];
+  doc["timestamp"] = strtoul(txArray["timestamp"].c_str(), nullptr, 10);
 
   //  Type
-  doc["type"] = txArray["type"];
+  doc["type"] = atoi(txArray["type"].c_str());
 
   //  VendorField
   if (std::strlen(txArray["vendorField"].c_str()) > 0) {
@@ -422,7 +420,7 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
 
   //  Version
   if (txArray["version"] != "0") {
-    doc["version"] = txArray["version"];
+    doc["version"] = atoi(txArray["version"].c_str());
   };
 
   char jsonChar[docCapacity];


### PR DESCRIPTION
Current implementation sometimes fails to properly serialize numbers in the `toJson()` method.
This is especially an issue in some Linux builds and all Arduino IDE builds (Arduino IDE Library Manager version (Cpp-Crypto-Arduino-v.0.3.0)).

Specifically, this PR does the following:
- moves `<cinttypes>` to `crypto_helpers.h` for non-IoT builds.
- forces type serialization for:
  - `amount` (llu/uint64_t).
  - `fee` (llu/uint64_t).
  - `network` (uint8_t/int).
  - `timestamp` (lu/uint32_t).
  - `type` (uint8_t/int).
  - `version` (uint8_t/int).
- updates the changelog.

This PR resolves #99.

Tests will fail until #101 is merged and this PR is rebased.

## What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included
