### PR TITLE
[arduino]chore(transaction): update amounts json

### DIFF
--- a/src/identities/address.cpp
+++ b/src/identities/address.cpp
@@ -121,14 +121,14 @@ std::string Ark::Crypto::Identities::Address::base58encode(
 
 std::vector<uint8_t> Ark::Crypto::Identities::Address::bytesFromBase58Check(
     const char* address) {
-  std::vector<std::uint8_t> recipientIdBytes;
-  recipientIdBytes.resize(Ripemd160::HASH_LEN);
+  std::vector<std::uint8_t> recipientBytes;
+  recipientBytes.resize(Ripemd160::HASH_LEN);
   uint8_t version = 0;
   Base58Check::pubkeyHashFromBase58Check(
       address,
-      &recipientIdBytes[0],
+      &recipientBytes[0],
       &version);
-  recipientIdBytes.insert(recipientIdBytes.begin(), version);
+  recipientBytes.insert(recipientBytes.begin(), version);
 
-  return recipientIdBytes;
+  return recipientBytes;
 }

--- a/src/transactions/builder.cpp
+++ b/src/transactions/builder.cpp
@@ -17,7 +17,7 @@ namespace Crypto {
 namespace Transactions {
 
 Transaction Builder::buildTransfer(
-    std::string recipientId,
+    std::string recipient,
     uint64_t amount,
     std::string vendorField,
     std::string passphrase,
@@ -28,7 +28,7 @@ Transaction Builder::buildTransfer(
 
   transaction.type = defaults::TransactionTypes::Transfer;
   transaction.fee = configuration.getFee(defaults::TransactionTypes::Transfer);
-  transaction.recipientId = std::move(recipientId);
+  transaction.recipient = std::move(recipient);
   transaction.amount = amount;
   transaction.vendorField = std::move(vendorField);
 
@@ -93,7 +93,7 @@ Transaction Builder::buildVote(
   const auto recipient = Identities::Address::fromPassphrase(
       passphrase.c_str(),
       configuration.getNetwork().version());
-  transaction.recipientId = recipient.toString();
+  transaction.recipient = recipient.toString();
 
   return sign(transaction,
       std::move(passphrase),
@@ -121,7 +121,7 @@ Transaction Builder::buildMultiSignatureRegistration(
   const auto recipient = Identities::Address::fromPassphrase(
       passphrase.c_str(),
       configuration.getNetwork().version());
-  transaction.recipientId = recipient.toString();
+  transaction.recipient = recipient.toString();
 
   return sign(
       transaction,

--- a/src/transactions/builder.h
+++ b/src/transactions/builder.h
@@ -31,7 +31,7 @@ public:
   * validation will fail.
   **/
   static Transaction buildTransfer(
-      std::string recipientId,
+      std::string recipient,
       uint64_t amount,
       std::string vendorField,
       std::string passphrase,

--- a/src/transactions/deserializer.cpp
+++ b/src/transactions/deserializer.cpp
@@ -107,7 +107,7 @@ void Deserializer::deserializeTransfer(
     Transaction& transaction) {
   unpack(&transaction.amount, &this->_binary[_assetOffset / 2]);
   unpack(&transaction.expiration, &this->_binary[_assetOffset / 2 + 8]);
-  transaction.recipientId = Identities::Address::base58encode(
+  transaction.recipient = Identities::Address::base58encode(
       &this->_binary[(_assetOffset / 2) + 12]);
 
   _assetOffset += (8 + 4 + 21) * 2;
@@ -253,7 +253,7 @@ void Deserializer::handleVersionOne(
     const auto address = Identities::Address::fromPublicKey(
         publicKey,
         transaction.network);
-    transaction.recipientId = address.toString();
+    transaction.recipient = address.toString();
   };
 
   if (transaction.type == defaults::TransactionTypes::MultiSignatureRegistration) {
@@ -280,7 +280,7 @@ void Deserializer::handleVersionOne(
     const auto address = Identities::Address::fromPublicKey(
         publicKey,
         transaction.network);
-    transaction.recipientId = address.toString();
+    transaction.recipient = address.toString();
   };
 }
 

--- a/src/transactions/serializer.cpp
+++ b/src/transactions/serializer.cpp
@@ -114,12 +114,12 @@ void Serializer::serializeTransfer(
   pack(bytes, _transaction.amount);
   pack(bytes, _transaction.expiration);
 
-  std::vector<uint8_t> recipientIdBytes = Identities::Address::bytesFromBase58Check(
-      _transaction.recipientId.c_str());
+  std::vector<uint8_t> recipientBytes = Identities::Address::bytesFromBase58Check(
+      _transaction.recipient.c_str());
   bytes.insert(
       bytes.end(),
-      recipientIdBytes.begin(),
-      recipientIdBytes.end());
+      recipientBytes.begin(),
+      recipientBytes.end());
 }
 
 /**/

--- a/src/transactions/transaction.cpp
+++ b/src/transactions/transaction.cpp
@@ -323,7 +323,8 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
   DynamicJsonDocument doc(docCapacity);
 
   //  Amount
-  doc["amount"] = strtoull(txArray["amount"].c_str(), nullptr, 10);
+  // >= Core v.2.5 'amount' json is string-type
+  doc["amount"] = txArray["amount"];
 
   //  Asset
   if (this->type == 0) {
@@ -365,7 +366,8 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
   };
 
   //  Fee
-  doc["fee"] = strtoull(txArray["fee"].c_str(), nullptr, 10);
+  // >= Core v.2.5 'amount' json is string-type
+  doc["fee"] = txArray["fee"];
 
   //  Id
   doc["id"] = txArray["id"];

--- a/src/transactions/transaction.cpp
+++ b/src/transactions/transaction.cpp
@@ -112,17 +112,17 @@ std::vector<uint8_t> Ark::Crypto::Transactions::Transaction::toBytes(
       std::begin(senderKeyBytes),
       std::end(senderKeyBytes));
 
-  const auto skipRecipientId =
+  const auto skiprecipient =
     type == defaults::TransactionTypes::SecondSignatureRegistration
     || type ==defaults::TransactionTypes::MultiSignatureRegistration;
 
-  if (!this->recipientId.empty() && !skipRecipientId) {
-    std::vector<std::uint8_t> recipientIdBytes = Address::bytesFromBase58Check(
-        this->recipientId.c_str());
+  if (!this->recipient.empty() && !skiprecipient) {
+    std::vector<std::uint8_t> recipientBytes = Address::bytesFromBase58Check(
+        this->recipient.c_str());
     bytes.insert(
         std::end(bytes),
-        std::begin(recipientIdBytes),
-        std::end(recipientIdBytes));
+        std::begin(recipientBytes),
+        std::end(recipientBytes));
   } else {
     std::vector<uint8_t> filler(21, 0);
     bytes.insert(
@@ -301,7 +301,7 @@ std::map<std::string, std::string> Ark::Crypto::Transactions::Transaction::toArr
     { "fee", fee },
     { "id", this->id },
     { "network", network },
-    { "recipientId", this->recipientId },
+    { "recipient", this->recipient },
     { "secondSignature", this->secondSignature },
     { "senderPublicKey", this->senderPublicKey },
     { "signature", this->signature },
@@ -377,8 +377,8 @@ std::string Ark::Crypto::Transactions::Transaction::toJson() {
     doc["network"] = atoi(txArray["network"].c_str());
   };
 
-  //  RecipientId
-  doc["recipientId"] = txArray["recipientId"];
+  //  Recipient
+  doc["recipient"] = txArray["recipient"];
 
   //  SecondSignature
   if (std::strlen(txArray["secondSignature"].c_str()) > 0) {

--- a/src/transactions/transaction.h
+++ b/src/transactions/transaction.h
@@ -63,7 +63,7 @@ public:
   uint32_t timelock_type = 0;
   std::vector<std::string> signatures = {};
   std::string id = "";
-  std::string recipientId = "";
+  std::string recipient = "";
   std::string senderPublicKey = "";
   std::string signature = "";
   std::string secondSignature = "";


### PR DESCRIPTION
This PR updates transaction json values to match Core 2.5 for the Arduino branch.

- transaction `amount` Json as string.
- transaction `fee` Json as string.

## What kind of change does this PR introduce?

- [x] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included
