### PR TITLE
[arduino] docs: update changelog and merge #93 from master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.6.0-arduino] - 2019-07-01
+## [0.6.0-arduino] - 2019-07-26
 
-## [0.6.0] - 2019-07-01
+## [0.6.0] - 2019-07-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.6.0-arduino] - 2019-07-26
+## [0.6.0-arduino] - 2019-07-16
 
-## [0.6.0] - 2019-07-26
+## [0.6.0] - 2019-07-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- changed amount and fee Json serialization to match Core v.2.5 ([#111])
 - improved PlatformIO configuration ([#101])
 - improved formatting and maintainability ([#98])
 - improved Slots implementations ([#92])

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/sdk/cryptography/cpp.html).
+You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/sdk/cryptography/usage.html).
 
 ## Security
 


### PR DESCRIPTION
This PR updates the changelog and  merges `master` #93 to `arduino`.
No idea how 93 slipped through 🤷‍♂ 

## What kind of change does this PR introduce?

- [x] Documentation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included