### PR TITLE
fix(crypto): fix crash in tests

### DIFF
--- a/src/crypto/curve.cpp
+++ b/src/crypto/curve.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <array>
 
 #include "interfaces/identities.hpp"
 #include "utils/crypto_helpers.h"
@@ -71,8 +72,7 @@ bool Curve::Ecdsa::sign(const uint8_t* hash32,
                    r, s);
 
   // Copy the big-endian bytes into and R and S element byte-buffers.
-  std::vector<uint8_t> rsBuffer;
-  rsBuffer.reserve(HASH_64_BYTE_LEN);
+  std::array<uint8_t, HASH_64_BYTE_LEN> rsBuffer = {};
   r.getBigEndianBytes(&rsBuffer[0]);
   s.getBigEndianBytes(&rsBuffer[HASH_32_BYTE_LEN]);
 


### PR DESCRIPTION
FIxed bug where an unallocated vector was being used.
Changed to use fix array since the buffer was never dynamic.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
