### PR TITLE
chore: remove `header-filter` clang-tidy call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ if(ENABLE_CLANG_TIDY)
 
     list(APPEND RUN_CLANG_TIDY_BIN_ARGS
         -clang-tidy-binary ${CLANG_TIDY_BIN}
-        "\"-header-filter=.*\\b(src|test|examples)\\b\\/(?!lib\/*).*\""     #Only run clang tidy on src, test, examples and skip 3rd party libraries
         -checks=clan*,cert*,misc*,perf*,cppc*,read*,mode*,-cert-err58-cpp,-misc-noexcept-move-constructor,-cppcoreguidelines-*
     )
 


### PR DESCRIPTION

## Summary

The regex call in `header-filter` doesn't work as expected.
The current behavior is identical to the default clang-tidy `-header-filter` default of `.*`.

You can see the regex not being obeyed in any of the passing "actions" or back on CircleCI.

https://github.com/ArkEcosystem/cpp-crypto/runs/244420978#step:6:1
https://github.com/ArkEcosystem/cpp-crypto/runs/242577996#step:6:1
https://circleci.com/gh/ArkEcosystem/cpp-crypto/1595

Since it doesn't work and is misleading, this PR removes that call.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

## Additional Comments.

CI will fail on PlatformIO builds due to not using explicit package versions.
A subsequent PR will address this issue.
