### PR TITLE
fix: cmake warnings

### DIFF
--- a/cmake/extern/ArduinoJson.txt.in
+++ b/cmake/extern/ArduinoJson.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+project(arduinojson-download)
+
 include(ExternalProject)
 
 # ------------------------------------------------------------------------------

--- a/cmake/extern/BIP66.txt.in
+++ b/cmake/extern/BIP66.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+project(bip66-download)
+
 include(ExternalProject)
 
 # ------------------------------------------------------------------------------

--- a/cmake/extern/GTest.txt.in
+++ b/cmake/extern/GTest.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+project(googletest-download)
+
 include(ExternalProject)
 
 # ------------------------------------------------------------------------------

--- a/cmake/extern/uECC.txt.in
+++ b/cmake/extern/uECC.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+project(uecc-download)
+
 include(ExternalProject)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

This PR adds project-download calls to silence external package build warnings.

## Checklist

- [x] Ready to be merged
