### PR TITLE
ci: call correct EXE for windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,4 +116,4 @@ jobs:
         run: msbuild "%GITHUB_WORKSPACE%\ark_cpp_crypto.sln"
       - name: Run Tests
         shell: cmd
-        run: "%GITHUB_WORKSPACE%\test\Debug\ark_cpp_crypto_tests.exe"
+        run: "%GITHUB_WORKSPACE%\\test\Debug\\ark_cpp_crypto_tests.exe"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,4 +116,4 @@ jobs:
         run: msbuild "%GITHUB_WORKSPACE%\ark_cpp_crypto.sln"
       - name: Run Tests
         shell: cmd
-        run: "%GITHUB_WORKSPACE%\\test\Debug\\ark_cpp_crypto_tests.exe"
+        run: "%GITHUB_WORKSPACE%\\test\\Debug\\ark_cpp_crypto_tests.exe"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,4 +115,4 @@ jobs:
         shell: cmd
         run: msbuild "%GITHUB_WORKSPACE%\ark_cpp_crypto.sln"
       - name: Run Tests
-        run: call "%GITHUB_WORKSPACE%\test\Debug\ark_cpp_crypto_tests"
+        run: "%GITHUB_WORKSPACE%\test\Debug\ark_cpp_crypto_tests.exe"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,4 +115,5 @@ jobs:
         shell: cmd
         run: msbuild "%GITHUB_WORKSPACE%\ark_cpp_crypto.sln"
       - name: Run Tests
+        shell: cmd
         run: "%GITHUB_WORKSPACE%\test\Debug\ark_cpp_crypto_tests.exe"


### PR DESCRIPTION
Corrected syntax in call to unit test exe

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
