### PR TITLE
Remove upload port used for debugging

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -140,7 +140,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${common_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_curve_ecdsa_sign_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -150,7 +149,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags}  ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_curve_ecdsa_sign_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_curve_ecdsa_sign_null_pk_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -160,7 +158,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags}  ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_curve_ecdsa_sign_null_pk_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_curve_ecdsa_sign_null_hash32_sha256_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -170,7 +167,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags}  ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_curve_ecdsa_sign_null_hash32_sha256_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_curve_ecdsa_sign_null_hash32_privatekey_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -180,7 +176,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags}  ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_curve_ecdsa_sign_null_hash32_privatekey_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_curve_publickey_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -190,7 +185,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_curve_publickey_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_curve_verify_invalid_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -200,7 +194,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_curve_verify_invalid_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_curve_verify_valid_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -210,7 +203,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_curve_verify_valid_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_hash_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -220,7 +212,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_hash_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_message_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -230,7 +221,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_message_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_message_sign_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -240,7 +230,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_message_sign_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_message_verify_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -250,7 +239,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_message_verify_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_crypto_slot_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -260,7 +248,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${crypto_slot_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_defaults_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -270,7 +257,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${defaults_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_identities_address_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -280,7 +266,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${identities_address_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_identities_keys_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -290,7 +275,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${identities_keys_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_identities_keys_publickey_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -300,7 +284,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${identities_keys_publickey_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_identities_privatekey_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -310,7 +293,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${identities_privatekey_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_identities_publickey_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -320,7 +302,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${identities_publickey_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_managers_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -330,7 +311,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${managers_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_networks_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -340,7 +320,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${networks_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_builder_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -350,7 +329,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_builder_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_builder_transfer_custom_network_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -360,7 +338,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_builder_transfer_custom_network_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_deserializer_delegate_registration_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -370,7 +347,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_deserializer_delegate_registration_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_deserializer_multi_signature_registration_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -380,7 +356,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_deserializer_multi_signature_registration_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_deserializer_second_signature_registration_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -390,7 +365,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_deserializer_second_signature_registration_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_deserializer_transfer_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -400,7 +374,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_deserializer_transfer_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_deserializer_vote_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -410,7 +383,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_deserializer_vote_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_serializer_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -420,7 +392,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_serializer_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_transaction_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -430,7 +401,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_transaction_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_transaction_to_array_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -440,7 +410,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_transaction_to_array_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_transactions_transaction_to_json_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -450,7 +419,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${transactions_transaction_to_json_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp8266_utils_tests]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -460,7 +428,6 @@ lib_deps = ${base.lib_deps}
 build_flags = ${base.build_flags} ${esp8266.build_flags}
 src_filter = ${base.src_filter} ${utils_tests.src_filter}
 upload_speed = ${base.upload_speed}
-upload_port = /dev/ttyUSB4
 
 [env:esp32_common_tests]
 platform = espressif32


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Explicit upload port set in PIO config was left in.  This was used for debugging on my specific machine.  It should be removed.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
