### PR TITLE
chore: update to use official googletest repo

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -16,7 +16,7 @@ libdeps_dir = ../extern/.piolibdeps
 
 [base]
 # Replace googletest library with proper release once ESP8266 support PR is merged to googletest
-lib_deps = ArduinoJson@6.12.0, BIP66@0.2.1, micro-ecc@1.0.0, https://github.com/ciband/googletest.git#pre_release
+lib_deps = ArduinoJson@6.12.0, BIP66@0.2.1, micro-ecc@1.0.0, https://github.com/google/googletest.git#master
 build_flags = -I../test -I../test/iot/ -I../src -I../src/lib -I../src/include/cpp-crypto -DUNIT_TEST
 src_filter = +<../src> +<../test/iot>
 upload_speed = 921600


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Google has official merged my PR to add esp8266 support to googletest.
This switches the dependency to use the official repo instead of my
fork.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
