### PR TITLE
refactor: remove usage of monolithic arkCrypto.h

### DIFF
--- a/examples/arduino/ESP32/ESP32.ino
+++ b/examples/arduino/ESP32/ESP32.ino
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  **/
- 
+
 /**
  * ESP32 Cpp-Crypto Usage Example Sketch
  *
@@ -24,15 +24,28 @@
 /**
  * This is where you include the 'arkCrypto.h' header.
  * This allows your project to use Ark Cpp-Crypto.
+ * This header is empty and is just to force the inclusion
+ * of the library into the Arduino sketch
  */
 #include <arkCrypto.h>
 /**/
+
+/**
+ * This is a helper header that includes all the required Ark
+ * headers required for this sketch.
+*/
+#include "arkCrypto_esp32.h"
+using namespace Ark::Crypto;
+using namespace Ark::Crypto::identities;
+using namespace Ark::Crypto::Transactions;
 
 /**
  * This is a small hex helper header included in ARK Cpp-Crypto
  */
 #include "utils/hex.hpp"
 /**/
+
+#include <Arduino.h>
 
 /****************************************/
 
@@ -66,23 +79,23 @@ void checkCrypto() {
 
   /**
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
-   * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'. 
+   * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
     Configuration config;
     unsigned long typeZeroTransactionFee = config.getFee(0);
     Serial.print("\nType 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.
-  
+
   /**/
 
   /********************/
 
   /**
-   * The following methods allows you to create an ARK address. 
+   * The following methods allows you to create an ARK address.
    * This is done by passing a 12-word 'Passphrase' and the 'Network' 'Version' "byte".
-   * The 'Version" "byte" is a BASE58 P2PKH byte. Ark Devnet is '0x1E'; Ark Mainnet is '0x17'. 
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   * The 'Version" "byte" is a BASE58 P2PKH byte. Ark Devnet is '0x1E'; Ark Mainnet is '0x17'.
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * and the 'Devnet' 'Version' byte (0x1E); the ARK Address should be "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib"
    */
   const auto passphrase = "this is a top secret passphrase";
@@ -97,10 +110,10 @@ void checkCrypto() {
   /********************/
 
   /**
-   * The following methods allows create a 'PrivateKey'. 
+   * The following methods allows create a 'PrivateKey'.
    * This is done by passing a 12-word 'Passphrase'.
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * the 'PrivateKey" should be "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712".
    * This is a 'SHA256' of your "Passphrase".
    */
@@ -113,10 +126,10 @@ void checkCrypto() {
   /********************/
 
   /**
-   * The following methods allows create a 'PublicKey'. 
+   * The following methods allows create a 'PublicKey'.
    * This is done by passing a 12-word 'Passphrase'.
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * the 'PublicKey" should be "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192".
    */
   const auto passphrase3 = "this is a top secret passphrase";
@@ -128,13 +141,13 @@ void checkCrypto() {
   /********************/
 
   /**
-   * The following methods allows create a 'WIF'-style "PrivateKey". 
+   * The following methods allows create a 'WIF'-style "PrivateKey".
    * 'WIF' stands for "Wallet Import Format"
    * This is done by passing a 12-word 'Passphrase' and the 'Network' 'WIF' "byte".
-   * The 'WIF" "byte" is a BASE58 WIF byte. Ark Devnet is '0xaa'; Ark Mainnet is also '0xaa'. 
+   * The 'WIF" "byte" is a BASE58 WIF byte. Ark Devnet is '0xaa'; Ark Mainnet is also '0xaa'.
 
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * and the 'Devnet' 'WIF' byte (0xaa);
    * The 'WIF" should be "SGq4xLgZKCGxs7bjmwnBrWcT4C1ADFEermj846KC97FSv1WFD1dA".
    */
@@ -148,11 +161,11 @@ void checkCrypto() {
   /********************/
 
   /**
-   * The following methods allows you to 'Sign' a text 'Message'. 
+   * The following methods allows you to 'Sign' a text 'Message'.
    * This is done by passing the text to be signed, and a 12-word 'Passphrase'.
-   * 
-   * Given the text "Hello World", 
-   * and the passphrase "this is a top secret passphrase", 
+   *
+   * Given the text "Hello World",
+   * and the passphrase "this is a top secret passphrase",
    * The 'Signature" should be "304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8".
    */
   const auto text = "Hello World";

--- a/examples/arduino/ESP32/arkCrypto_esp32.h
+++ b/examples/arduino/ESP32/arkCrypto_esp32.h
@@ -1,0 +1,22 @@
+/**
+ * This file is part of Ark Cpp Crypto.
+ *
+ * (c) Ark Ecosystem <info@ark.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ **/
+
+#ifndef ARK_CRYPTO_ESP32_H
+#define ARK_CRYPTO_ESP32_H
+
+#include "common/configuration.hpp"
+#include "common/network.hpp"
+#include "crypto/message.hpp"
+#include "identities/address.hpp"
+#include "identities/privatekey.hpp"
+#include "identities/publickey.hpp"
+#include "identities/wif.hpp"
+#include "transactions/builder.h"
+
+#endif

--- a/examples/arduino/ESP8266/ESP8266.ino
+++ b/examples/arduino/ESP8266/ESP8266.ino
@@ -33,6 +33,8 @@
 /**
  * This is a helper header that includes all the required Ark
  * headers required for this sketch.
+ * 
+ * Also set the CPU frequency to 160MHz using the Arduino IDE's 'Tools' menu.
 */
 #include "arkCrypto_esp8266.h"
 using namespace Ark::Crypto;

--- a/examples/arduino/ESP8266/ESP8266.ino
+++ b/examples/arduino/ESP8266/ESP8266.ino
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  **/
- 
+
 /**
  * ESP8266 Cpp-Crypto Usage Example Sketch
  *
@@ -18,15 +18,26 @@
  * NOTE: At the time of this writing, the Cpp-Crypto library requires running the 'ARDUINO_IDE.sh' bash script located in the 'extras' folder.
  * This converts our library to be compatible with the Arduino IDE.
  */
- 
+
 /****************************************/
 
 /**
  * This is where you include the 'arkCrypto.h' header.
  * This allows your project to use Ark Cpp-Crypto.
+ * This header is empty and is just to force the inclusion
+ * of the library into the Arduino sketch
  */
 #include <arkCrypto.h>
 /**/
+
+/**
+ * This is a helper header that includes all the required Ark
+ * headers required for this sketch.
+*/
+#include "arkCrypto_esp8266.h"
+using namespace Ark::Crypto;
+using namespace Ark::Crypto::identities;
+using namespace Ark::Crypto::Transactions;
 
 /****************************************/
 
@@ -59,23 +70,23 @@ void checkCrypto() {
 
   /**
    * This is how you can check the default 'Network' "Transaction 'Fees' by type.
-   * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'. 
+   * In this example, it should return a 'uint64_t' integer of '10000000' as the default 'Fee' for a 'Transaction' of 'Type' '0'.
    */
     Configuration config;
     unsigned long typeZeroTransactionFee = config.getFee(0);
     Serial.print("\nType 0 default Transaction Fee: ");
     Serial.println(typeZeroTransactionFee); // The response is a 'uint64_t' integer.
-  
+
   /**/
 
   /********************/
 
   /**
-   * The following methods allows you to create an ARK address. 
+   * The following methods allows you to create an ARK address.
    * This is done by passing a 12-word 'Passphrase' and the 'Network' 'Version' "byte".
-   * The 'Version" "byte" is a BASE58 P2PKH byte. Ark Devnet is '0x1E'; Ark Mainnet is '0x17'. 
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   * The 'Version" "byte" is a BASE58 P2PKH byte. Ark Devnet is '0x1E'; Ark Mainnet is '0x17'.
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * and the 'Devnet' 'Version' byte (0x1E); the ARK Address should be "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib"
    */
   const auto passphrase = "this is a top secret passphrase";
@@ -90,10 +101,10 @@ void checkCrypto() {
   /********************/
 
   /**
-   * The following methods allows create a 'PrivateKey'. 
+   * The following methods allows create a 'PrivateKey'.
    * This is done by passing a 12-word 'Passphrase'.
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * the 'PrivateKey" should be "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712".
    * This is a 'SHA256' of your "Passphrase".
    */
@@ -106,10 +117,10 @@ void checkCrypto() {
   /********************/
 
   /**
-   * The following methods allows create a 'PublicKey'. 
+   * The following methods allows create a 'PublicKey'.
    * This is done by passing a 12-word 'Passphrase'.
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * the 'PublicKey" should be "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192".
    */
   const auto passphrase3 = "this is a top secret passphrase";
@@ -121,13 +132,13 @@ void checkCrypto() {
   /********************/
 
   /**
-   * The following methods allows create a 'WIF'-style "PrivateKey". 
+   * The following methods allows create a 'WIF'-style "PrivateKey".
    * 'WIF' stands for "Wallet Import Format"
    * This is done by passing a 12-word 'Passphrase' and the 'Network' 'WIF' "byte".
-   * The 'WIF" "byte" is a BASE58 WIF byte. Ark Devnet is '0xaa'; Ark Mainnet is also '0xaa'. 
+   * The 'WIF" "byte" is a BASE58 WIF byte. Ark Devnet is '0xaa'; Ark Mainnet is also '0xaa'.
 
-   * 
-   * Given the passphrase "this is a top secret passphrase", 
+   *
+   * Given the passphrase "this is a top secret passphrase",
    * and the 'Devnet' 'WIF' byte (0xaa);
    * The 'WIF" should be "SGq4xLgZKCGxs7bjmwnBrWcT4C1ADFEermj846KC97FSv1WFD1dA".
    */

--- a/examples/arduino/ESP8266/arkCrypto_esp8266.h
+++ b/examples/arduino/ESP8266/arkCrypto_esp8266.h
@@ -1,0 +1,22 @@
+/**
+ * This file is part of Ark Cpp Crypto.
+ *
+ * (c) Ark Ecosystem <info@ark.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ **/
+
+#ifndef ARK_CRYPTO_ESP8266_H
+#define ARK_CRYPTO_ESP8266_H
+
+#include "common/configuration.hpp"
+#include "common/network.hpp"
+#include "crypto/message.hpp"
+#include "identities/address.hpp"
+#include "identities/privatekey.hpp"
+#include "identities/publickey.hpp"
+#include "identities/wif.hpp"
+#include "transactions/builder.h"
+
+#endif

--- a/src/include/cpp-crypto/arkCrypto.h
+++ b/src/include/cpp-crypto/arkCrypto.h
@@ -10,6 +10,6 @@
 #ifndef ARK_CRYPTO_H
 #define ARK_CRYPTO_H
 
-// This is a dummy include to force the Arduino library system to search for the library
+// This header forces the Arduino IDE to include ARK Crypto in its search path.
 
 #endif

--- a/src/include/cpp-crypto/arkCrypto.h
+++ b/src/include/cpp-crypto/arkCrypto.h
@@ -10,33 +10,6 @@
 #ifndef ARK_CRYPTO_H
 #define ARK_CRYPTO_H
 
-#include "common/configuration.hpp"
-#include "common/fee_policy.hpp"
-#include "common/network.hpp"
-
-#include "crypto/message.hpp"
-#include "crypto/slot.hpp"
-
-#include "defaults/static_fees.hpp"
-#include "defaults/transaction_types.hpp"
-
-#include "identities/address.hpp"
-#include "identities/keys.hpp"
-#include "identities/privatekey.hpp"
-#include "identities/publickey.hpp"
-#include "identities/wif.hpp"
-
-#include "networks/devnet.hpp"
-#include "networks/mainnet.hpp"
-#include "networks/testnet.hpp"
-
-#include "transactions/builder.h"
-#include "transactions/deserializer.h"
-#include "transactions/serializer.h"
-#include "transactions/transaction.h"
-
-using namespace Ark::Crypto;
-using namespace Ark::Crypto::identities;
-using namespace Ark::Crypto::Transactions;
+// This is a dummy include to force the Arduino library system to search for the library
 
 #endif

--- a/test/common/configuration.cpp
+++ b/test/common/configuration.cpp
@@ -3,7 +3,11 @@
 
 #include <cstdint>
 
-#include <arkCrypto.h>
+#include "common/configuration.hpp"
+#include "common/fee_policy.hpp"
+#include "networks/devnet.hpp"
+#include "networks/testnet.hpp"
+using namespace Ark::Crypto;
 
 namespace {
 const FeePolicy CustomFeePolicy = {

--- a/test/common/fee_policy.cpp
+++ b/test/common/fee_policy.cpp
@@ -1,7 +1,8 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include "common/fee_policy.hpp"
+using namespace Ark::Crypto;
 
 namespace {
 const FeePolicy CustomFeePolicy = {

--- a/test/common/network.cpp
+++ b/test/common/network.cpp
@@ -1,7 +1,9 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include "common/network.hpp"
+#include "networks/devnet.hpp"
+using namespace Ark::Crypto;
 
 namespace {
 const Network CustomNetwork {

--- a/test/defaults/static_fees.cpp
+++ b/test/defaults/static_fees.cpp
@@ -3,7 +3,8 @@
 
 #include <cstdint>
 
-#include <arkCrypto.h>
+#include "defaults/static_fees.hpp"
+using namespace Ark::Crypto;
 
 namespace {
 constexpr const uint64_t kTransfer                    = 10000000ULL;

--- a/test/defaults/transaction_types.cpp
+++ b/test/defaults/transaction_types.cpp
@@ -1,7 +1,10 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include <cstdint>
+
+#include "defaults/transaction_types.hpp"
+using namespace Ark::Crypto;
 
 namespace {
 constexpr const uint8_t TransferType                    = 0;

--- a/test/transactions/deserializer_multi_signature_registration.cpp
+++ b/test/transactions/deserializer_multi_signature_registration.cpp
@@ -1,11 +1,19 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "defaults/transaction_types.hpp"
+#include "identities/address.hpp"
+#include "identities/publickey.hpp"
+#include "transactions/deserializer.h"
+using namespace Ark::Crypto;
 
 TEST(transactions, deserialize_multi_signature_registration) { // NOLINT
   // multi_signature_registration/passphrase.json
-  Ark::Crypto::Transactions::Deserializer deserializer(
+  Transactions::Deserializer deserializer(
       "ff011704724c9a00036928c98ee53a1f52ed01dd87db10ffe1980eb47cd7c0a7d688321f47b5d7d76000943577000000000002031803543c"
       "6cc3545be6bac09c82721973a052c690658283472e88f24d14739f75acc80276dc5b8706a85ca9fdc46e571ac84e52fbb48e13ec7a165a80"
       "731b44ae89f1fc02e8d5d17eb17bbc8d7bf1001d29a2d25d1249b7bb7a5b7ad8b7422063091f4b3130440220324d89c5792e4a54ae70b4f1"

--- a/test/transactions/deserializer_second_signature_registration.cpp
+++ b/test/transactions/deserializer_second_signature_registration.cpp
@@ -1,7 +1,11 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include "defaults/transaction_types.hpp"
+#include "identities/address.hpp"
+#include "identities/publickey.hpp"
+#include "transactions/deserializer.h"
+using namespace Ark::Crypto;
 
 TEST(transactions, deserialize_second_signature_registration) { // NOLINT
   // second_signature_registration/second-passphrase.json

--- a/test/transactions/deserializer_transfer.cpp
+++ b/test/transactions/deserializer_transfer.cpp
@@ -1,7 +1,9 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include "defaults/transaction_types.hpp"
+#include "transactions/deserializer.h"
+using namespace Ark::Crypto;
 
 TEST(transactions, deserialize_transfer) { // NOLINT
   // transfer/passphrase-with-vendor-field.json

--- a/test/transactions/deserializer_vote.cpp
+++ b/test/transactions/deserializer_vote.cpp
@@ -1,7 +1,12 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include <string>
+#include <vector>
+
+#include "defaults/transaction_types.hpp"
+#include "transactions/deserializer.h"
+using namespace Ark::Crypto;
 
 TEST(transactions, deserialize_vote) { // NOLINT
   // vote/second-passphrase.json

--- a/test/transactions/serializer.cpp
+++ b/test/transactions/serializer.cpp
@@ -1,7 +1,9 @@
 
 #include "gtest/gtest.h"
 
-#include <arkCrypto.h>
+#include <string>
+
+#include "transactions/serializer.h"
 
 TEST(transactions, serialize_transfer) { // NOLINT
   // transfer/passphrase-with-vendor-field.json

--- a/test/transactions/transaction.cpp
+++ b/test/transactions/transaction.cpp
@@ -4,10 +4,9 @@
 #include <map>
 #include <string>
 
-#include <arkCrypto.h>
-
+#include "transactions/transaction.h"
 #include "utils/json.h"
-
+using namespace Ark::Crypto;
 using namespace Ark::Crypto::Transactions;
 
 TEST(transactions, transaction_default) {

--- a/test/transactions/transaction_to_json_type_0.cpp
+++ b/test/transactions/transaction_to_json_type_0.cpp
@@ -4,10 +4,9 @@
 #include <map>
 #include <string>
 
-#include <arkCrypto.h>
-
+#include "transactions/builder.h"
 #include "utils/json.h"
-
+using namespace Ark::Crypto;
 using namespace Ark::Crypto::Transactions;
 
 TEST(transactions, transaction_to_json_type_0) {  // NOLINT

--- a/test/transactions/transaction_to_json_type_1.cpp
+++ b/test/transactions/transaction_to_json_type_1.cpp
@@ -4,10 +4,9 @@
 #include <map>
 #include <string>
 
-#include <arkCrypto.h>
-
+#include "transactions/builder.h"
 #include "utils/json.h"
-
+using namespace Ark::Crypto;
 using namespace Ark::Crypto::Transactions;
 
 TEST(transactions, transaction_to_json_type_1) {  // NOLINT

--- a/test/transactions/transaction_to_json_type_2.cpp
+++ b/test/transactions/transaction_to_json_type_2.cpp
@@ -4,10 +4,9 @@
 #include <map>
 #include <string>
 
-#include <arkCrypto.h>
-
+#include "transactions/builder.h"
 #include "utils/json.h"
-
+using namespace Ark::Crypto;
 using namespace Ark::Crypto::Transactions;
 
 TEST(transactions, transaction_to_json_type_2) {  // NOLINT

--- a/test/transactions/transaction_to_json_type_3.cpp
+++ b/test/transactions/transaction_to_json_type_3.cpp
@@ -4,10 +4,9 @@
 #include <map>
 #include <string>
 
-#include <arkCrypto.h>
-
+#include "transactions/builder.h"
 #include "utils/json.h"
-
+using namespace Ark::Crypto;
 using namespace Ark::Crypto::Transactions;
 
 TEST(transactions, transaction_to_json_type_3) {  // NOLINT


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

* Updated arkCrypto.h header to just be a dummy header for the sole
   purpose of forcing the cpp-crypto library to be linked into an
   Arduino sketch.
* Updated tests to use specific headers instead of arkCrypto.h
* Updated Arduino sample sketches to use only the headers required
   for the sketch.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
