### PR TITLE
build: hide cmake warnings

### DIFF
--- a/cmake/extern/ArduinoJson.txt.in
+++ b/cmake/extern/ArduinoJson.txt.in
@@ -12,6 +12,7 @@ include(ExternalProject)
 ExternalProject_Add(ArduinoJson
   GIT_REPOSITORY    https://github.com/bblanchon/ArduinoJson
   GIT_TAG           v6.12.0
+  GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/arduinojson/src"
   BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/arduinojson/build"
   CONFIGURE_COMMAND ""

--- a/cmake/extern/BIP66.txt.in
+++ b/cmake/extern/BIP66.txt.in
@@ -12,6 +12,7 @@ include(ExternalProject)
 ExternalProject_Add(BIP66
   GIT_REPOSITORY    https://github.com/sleepdefic1t/BIP66
   GIT_TAG           0.2.1
+  GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/bip66/src"
   BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/bip66/build"
   CONFIGURE_COMMAND ""

--- a/cmake/extern/GTest.txt.in
+++ b/cmake/extern/GTest.txt.in
@@ -12,6 +12,7 @@ include(ExternalProject)
 ExternalProject_Add(GoogleTest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           v1.10.x
+  GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/src"
   BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/googletest/build"
   CONFIGURE_COMMAND ""

--- a/cmake/extern/uECC.txt.in
+++ b/cmake/extern/uECC.txt.in
@@ -12,6 +12,7 @@ include(ExternalProject)
 ExternalProject_Add(UECC
   GIT_REPOSITORY    https://github.com/kmackay/micro-ecc
   GIT_TAG           v1.0
+  GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${EXTERNAL_LIBRARY_DIR}/uecc/src"
   BINARY_DIR        "${EXTERNAL_LIBRARY_DIR}/uecc/build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION

## Summary

- ignores detached head warnings when cloning external libs from CMake.

## Checklist

- [x] Ready to be merged
