### PR TITLE
fix(transactions): htlc claim secret [arduino]

### DIFF
--- a/src/transactions/types/htlc_claim.cpp
+++ b/src/transactions/types/htlc_claim.cpp
@@ -99,9 +99,7 @@ void HtlcClaim::addToMap(const HtlcClaim &claim,
     map.emplace(KEY_CLAIM_TX_ID_LABEL, BytesToHex(claim.id));
 
     // Secret
-    std::string secret(claim.secret.size(), '\0');
-    secret.insert(secret.begin(), claim.secret.begin(), claim.secret.end());    
-    map.emplace(KEY_CLAIM_SECRET_LABEL, secret);
+    map.emplace(KEY_CLAIM_SECRET_LABEL, BytesToHex(claim.secret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION

## Summary

- fix Htlc Claim unlockSecret Json to display as a 64-char hash.

## Checklist

- [x] Ready to be merged
