### PR TITLE
chore(transactions): use explicit size vs strlen for labels [arduino]

### DIFF
--- a/src/interfaces/constants.h
+++ b/src/interfaces/constants.h
@@ -11,7 +11,6 @@
 #define ARK_INTERFACES_CONSTANTS_H
 
 #include <cstddef>
-#include <cstring>
 
 #include "utils/platform.h"
 
@@ -73,11 +72,11 @@ constexpr size_t WIF_STRING_LEN         = 52U;
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
-constexpr auto KEY_ASSET_LABEL  = "asset";
-const auto KEY_ASSET_SIZE       = strlen(KEY_ASSET_LABEL);
+constexpr auto KEY_ASSET_LABEL      = "asset";
+constexpr size_t KEY_ASSET_SIZE     = 5;
 
-constexpr auto KEY_AMOUNT_LABEL = "amount";
-const auto KEY_AMOUNT_SIZE      = strlen(KEY_AMOUNT_LABEL);
+constexpr auto KEY_AMOUNT_LABEL     = "amount";
+constexpr size_t KEY_AMOUNT_SIZE    = 6;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Misc

--- a/src/transactions/mapping/labels.hpp
+++ b/src/transactions/mapping/labels.hpp
@@ -10,7 +10,7 @@
 #ifndef ARK_TRANSACTIONS_MAPPING_LABELS_HPP
 #define ARK_TRANSACTIONS_MAPPING_LABELS_HPP
 
-#include <string>
+#include <cstddef>
 
 namespace Ark {
 namespace Crypto {
@@ -19,40 +19,40 @@ namespace transactions {  // NOLINT
 ////////////////////////////////////////////////////////////////////////////////
 // Mapping Label Constants
 constexpr auto KEY_VERSION_LABEL            = "version";
-const auto KEY_VERSION_SIZE                 = strlen(KEY_VERSION_LABEL);
+constexpr size_t KEY_VERSION_SIZE           = 7;
 
 constexpr auto KEY_NETWORK_LABEL            = "network";
-const auto KEY_NETWORK_SIZE                 = strlen(KEY_NETWORK_LABEL);
+constexpr size_t  KEY_NETWORK_SIZE          = 7;
 
 constexpr auto KEY_TYPEGROUP_LABEL          = "typeGroup";
-const auto KEY_TYPEGROUP_SIZE               = strlen(KEY_TYPEGROUP_LABEL);
+constexpr size_t KEY_TYPEGROUP_SIZE         = 8;
 
 constexpr auto KEY_TYPE_LABEL               = "type";
-const auto KEY_TYPE_SIZE                    = strlen(KEY_TYPE_LABEL);
+constexpr size_t KEY_TYPE_SIZE              = 4;
 
 constexpr auto KEY_NONCE_LABEL              = "nonce";
-const auto KEY_NONCE_SIZE                   = strlen(KEY_NONCE_LABEL);
+constexpr size_t KEY_NONCE_SIZE             = 5;
 
 constexpr auto KEY_TIMESTAMP_LABEL          = "timestamp";
-const auto KEY_TIMESTAMP_SIZE               = strlen(KEY_TIMESTAMP_LABEL);
+constexpr size_t KEY_TIMESTAMP_SIZE         = 9;
 
 constexpr auto KEY_SENDER_PUBLICKEY_LABEL   = "senderPublicKey";
-const auto KEY_SENDER_PUBLICKEY_SIZE        = strlen(KEY_SENDER_PUBLICKEY_LABEL);
+constexpr size_t KEY_SENDER_PUBLICKEY_SIZE  = 15;
 
 constexpr auto KEY_FEE_LABEL                = "fee";
-const auto KEY_FEE_SIZE                     = strlen(KEY_FEE_LABEL);
+constexpr size_t KEY_FEE_SIZE               = 3;
 
 constexpr auto KEY_VENDORFIELD_LABEL        = "vendorField";
-const auto KEY_VENDORFIELD_SIZE             = strlen(KEY_VENDORFIELD_LABEL);
+constexpr size_t KEY_VENDORFIELD_SIZE       = 11;
 
 constexpr auto KEY_SIGNATURE_LABEL          = "signature";
-const auto KEY_SIGNATURE_SIZE               = strlen(KEY_SIGNATURE_LABEL);
+constexpr size_t KEY_SIGNATURE_SIZE         = 9;
 
 constexpr auto KEY_SECOND_SIGNATURE_LABEL   = "secondSignature";
-const auto KEY_SECOND_SIGNATURE_SIZE        = strlen(KEY_SECOND_SIGNATURE_LABEL);
+constexpr size_t KEY_SECOND_SIGNATURE_SIZE  = 15;
 
 constexpr auto KEY_ID_LABEL                 = "id";
-const auto KEY_ID_SIZE                      = strlen(KEY_ID_LABEL);
+constexpr size_t KEY_ID_SIZE                = 2;
 
 }  // namespace transactions
 }  // namespace Crypto

--- a/src/transactions/types/delegate_registration.cpp
+++ b/src/transactions/types/delegate_registration.cpp
@@ -10,9 +10,9 @@
 #include "transactions/types/delegate_registration.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <map>
-#include <string>
 
 #include "utils/json.h"
 #include "utils/str.hpp"
@@ -92,10 +92,10 @@ auto DelegateRegistration::Serialize(const DelegateRegistration &registration,
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
 constexpr auto OBJECT_DELEGATE_LABEL    = "delegate";
-const auto KEY_DELEGATE_SIZE            = strlen(OBJECT_DELEGATE_LABEL);
+constexpr size_t KEY_DELEGATE_SIZE      = 8;
 
 constexpr auto KEY_USERNAME_LABEL       = "username";
-const auto KEY_USERNAME_SIZE            = strlen(KEY_USERNAME_LABEL);
+constexpr size_t KEY_USERNAME_SIZE      = 8;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add Delegate Registration Asset data to a Transaction Map.

--- a/src/transactions/types/htlc_claim.cpp
+++ b/src/transactions/types/htlc_claim.cpp
@@ -10,9 +10,9 @@
 #include "transactions/types/htlc_claim.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <map>
-#include <string>
 
 #include "interfaces/constants.h"
 
@@ -82,14 +82,14 @@ auto HtlcClaim::Serialize(const HtlcClaim &claim, uint8_t *buffer) -> size_t {
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
-constexpr auto OBJECT_HTLC_CLAIM_LABEL  = "claim";
-const auto OBJECT_HTLC_CLAIM_SIZE       = strlen(OBJECT_HTLC_CLAIM_LABEL);
+constexpr auto OBJECT_HTLC_CLAIM_LABEL      = "claim";
+constexpr size_t OBJECT_HTLC_CLAIM_SIZE     = 5;
 
-constexpr auto KEY_CLAIM_TX_ID_LABEL    = "lockTransactionId";
-const auto KEY_CLAIM_TX_ID_SIZE         = strlen(KEY_CLAIM_TX_ID_LABEL);
+constexpr auto KEY_CLAIM_TX_ID_LABEL        = "lockTransactionId";
+constexpr size_t KEY_CLAIM_TX_ID_SIZE       = 17;
 
-constexpr auto KEY_CLAIM_SECRET_LABEL   = "unlockSecret";
-const auto KEY_CLAIM_SECRET_SIZE        = strlen(KEY_CLAIM_SECRET_LABEL);
+constexpr auto KEY_CLAIM_SECRET_LABEL       = "unlockSecret";
+constexpr size_t KEY_CLAIM_SECRET_SIZE      = 11;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add Htlc Claim Asset data to a Transaction Map.

--- a/src/transactions/types/htlc_lock.cpp
+++ b/src/transactions/types/htlc_lock.cpp
@@ -10,6 +10,7 @@
 #include "transactions/types/htlc_lock.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>
@@ -146,26 +147,26 @@ auto HtlcLock::Serialize(const HtlcLock &lock, uint8_t *buffer) -> size_t {
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
-constexpr auto OBJECT_HTLC_LOCK_LABEL       = "lock";
-const auto OBJECT_HTLC_LOCK_SIZE            = strlen(OBJECT_HTLC_LOCK_LABEL) - 1U;
+constexpr auto OBJECT_HTLC_LOCK_LABEL           = "lock";
+constexpr size_t OBJECT_HTLC_LOCK_SIZE          = 4;
 
-constexpr auto OBJECT_HTLC_LOCK_TYPE_LABEL  = "type";
-const auto OBJECT_HTLC_LOCK_VALUE_LABEL     = "value";
+constexpr auto OBJECT_HTLC_LOCK_TYPE_LABEL      = "type";
+constexpr auto OBJECT_HTLC_LOCK_VALUE_LABEL     = "value";
 
-constexpr auto KEY_AMOUNT_LABEL             = "amount";
-const auto KEY_AMOUNT_SIZE                  = strlen(KEY_AMOUNT_LABEL);
+constexpr auto KEY_AMOUNT_LABEL                 = "amount";
+constexpr size_t KEY_AMOUNT_SIZE                = 6;
 
-constexpr auto KEY_SECRET_HASH_LABEL        = "secretHash";
-const auto KEY_SECRET_HASH_SIZE             = strlen(KEY_SECRET_HASH_LABEL);
+constexpr auto KEY_SECRET_HASH_LABEL            = "secretHash";
+constexpr size_t KEY_SECRET_HASH_SIZE           = 10;
 
-constexpr auto KEY_EXPIRATION_TYPE_LABEL    = "expirationType";
-const auto KEY_EXPIRATION_TYPE_SIZE         = strlen(KEY_EXPIRATION_TYPE_LABEL);
+constexpr auto KEY_EXPIRATION_TYPE_LABEL        = "expirationType";
+constexpr size_t KEY_EXPIRATION_TYPE_SIZE       = 14;
 
-constexpr auto KEY_EXPIRATION_LABEL         = "expiration";
-const auto KEY_EXPIRATION_SIZE              = strlen(KEY_EXPIRATION_LABEL);
+constexpr auto KEY_EXPIRATION_LABEL             = "expiration";
+constexpr size_t KEY_EXPIRATION_SIZE            = 10;
 
-constexpr auto KEY_RECIPIENT_ID_LABEL       = "recipientId";
-const auto KEY_RECIPIENT_ID_SIZE            = strlen(KEY_RECIPIENT_ID_LABEL);
+constexpr auto KEY_RECIPIENT_ID_LABEL           = "recipientId";
+constexpr size_t KEY_RECIPIENT_ID_SIZE          = 11;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add Htlc Lock Asset data to a Transaction Map.

--- a/src/transactions/types/htlc_refund.cpp
+++ b/src/transactions/types/htlc_refund.cpp
@@ -10,9 +10,9 @@
 #include "transactions/types/htlc_refund.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <map>
-#include <string>
 
 #include "interfaces/constants.h"
 
@@ -70,11 +70,11 @@ auto HtlcRefund::Serialize(const HtlcRefund &refund, uint8_t *buffer)
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
-constexpr auto OBJECT_HTLC_REFUND_LABEL = "refund";
-const auto OBJECT_HTLC_REFUND_SIZE      = strlen(OBJECT_HTLC_REFUND_LABEL);
+constexpr auto OBJECT_HTLC_REFUND_LABEL     = "refund";
+constexpr size_t OBJECT_HTLC_REFUND_SIZE    = 6;
 
-constexpr auto KEY_REFUND_TX_ID_LABEL   = "lockTransactionId";
-const auto KEY_REFUND_TX_ID_SIZE        = strlen(KEY_REFUND_TX_ID_LABEL);
+constexpr auto KEY_REFUND_TX_ID_LABEL       = "lockTransactionId";
+constexpr size_t KEY_REFUND_TX_ID_SIZE      = 17;
 
 constexpr auto HTLC_JSON_OBJECT_SIZE = 1U;
 

--- a/src/transactions/types/ipfs.cpp
+++ b/src/transactions/types/ipfs.cpp
@@ -10,9 +10,9 @@
 #include "transactions/types/ipfs.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <map>
-#include <string>
 
 #include "interfaces/constants.h"
 
@@ -84,7 +84,7 @@ auto Ipfs::Serialize(const Ipfs &ipfs, uint8_t *buffer) -> size_t {
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
 constexpr auto KEY_IPFS_LABEL   = "ipfs";
-const auto KEY_IPFS_SIZE        = strlen(KEY_IPFS_LABEL);
+constexpr size_t KEY_IPFS_SIZE  = 4;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add Ipfs Asset data to a Transaction Map.

--- a/src/transactions/types/multi_payment.cpp
+++ b/src/transactions/types/multi_payment.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <numeric>  // std::accumulate
@@ -164,19 +165,19 @@ auto MultiPayment::Serialize(const MultiPayment &payments,
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
-constexpr auto KEY_PAYMENTS_LABEL   = "payments";
-const auto KEY_PAYMENTS_SIZE        = strlen(KEY_PAYMENTS_LABEL);
+constexpr auto KEY_PAYMENTS_LABEL       = "payments";
+constexpr size_t KEY_PAYMENTS_SIZE      = 8;
 
-const auto KEY_N_PAYMENTS_SIZE      = strlen(KEY_N_PAYMENTS_LABEL);
+constexpr size_t KEY_N_PAYMENTS_SIZE    = 9;
 
-constexpr auto KEY_AMOUNTS_LABEL    = "amounts";
-const auto KEY_AMOUNTS_SIZE         = strlen(KEY_AMOUNTS_LABEL);
+constexpr auto KEY_AMOUNTS_LABEL        = "amounts";
+constexpr size_t KEY_AMOUNTS_SIZE       = 7;
 
-constexpr auto KEY_ADDRESSES_LABEL  = "addresses";
-const auto KEY_ADDRESSES_SIZE       = strlen(KEY_ADDRESSES_LABEL);
+constexpr auto KEY_ADDRESSES_LABEL      = "addresses";
+constexpr size_t KEY_ADDRESSES_SIZE     = 9;
 
 constexpr auto KEY_RECIPIENT_ID_LABEL   = "recipientId";
-const auto KEY_RECIPIENT_ID_SIZE        = strlen(KEY_RECIPIENT_ID_LABEL);
+constexpr size_t KEY_RECIPIENT_ID_SIZE  = 11;
 
 constexpr auto MULTIPAYMENT_JSON_OBJECT_SIZE = 2U;
 

--- a/src/transactions/types/second_signature.cpp
+++ b/src/transactions/types/second_signature.cpp
@@ -10,9 +10,9 @@
 #include "transactions/types/second_signature.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <map>
-#include <string>
 
 #include "interfaces/constants.h"
 
@@ -75,10 +75,10 @@ auto SecondSignature::Serialize(const SecondSignature &registration,
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
 constexpr auto KEY_SIGNATURE_LABEL      = "signature";
-const auto KEY_SIGNATURE_SIZE           = strlen(KEY_SIGNATURE_LABEL);
+constexpr size_t KEY_SIGNATURE_SIZE     = 9;
 
 constexpr auto KEY_PUBLICKEY_LABEL      = "publicKey";
-const auto KEY_PUBLICKEY_SIZE           = strlen(KEY_PUBLICKEY_LABEL);
+constexpr size_t KEY_PUBLICKEY_SIZE     = 9;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add SecondSignature Asset data to a Transaction Map.

--- a/src/transactions/types/transfer.cpp
+++ b/src/transactions/types/transfer.cpp
@@ -10,10 +10,9 @@
 #include "transactions/types/transfer.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <map>
-#include <string>
 
 #include "interfaces/constants.h"
 
@@ -97,13 +96,13 @@ auto Transfer::Serialize(const Transfer &transfer, uint8_t *buffer) -> size_t {
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
 constexpr auto KEY_AMOUNT_LABEL         = "amount";
-const auto KEY_AMOUNT_SIZE              = strlen(KEY_AMOUNT_LABEL);
+constexpr size_t KEY_AMOUNT_SIZE        = 6;
 
 constexpr auto KEY_EXPIRATION_LABEL     = "expiration";
-const auto KEY_EXPIRATION_SIZE          = strlen(KEY_EXPIRATION_LABEL);
+constexpr size_t KEY_EXPIRATION_SIZE    = 10;
 
 constexpr auto KEY_RECIPIENT_ID_LABEL   = "recipientId";
-const auto KEY_RECIPIENT_ID_SIZE        = strlen(KEY_RECIPIENT_ID_LABEL);
+constexpr size_t KEY_RECIPIENT_ID_SIZE  = 11;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add Transfer Asset data to a Transaction Map.

--- a/src/transactions/types/vote.cpp
+++ b/src/transactions/types/vote.cpp
@@ -10,9 +10,9 @@
 #include "transactions/types/vote.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <map>
-#include <string>
 
 #include "interfaces/constants.h"
 
@@ -79,11 +79,11 @@ auto Vote::Serialize(const Vote &vote, uint8_t *buffer) -> size_t {
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Map/Json Constants
-constexpr auto KEY_VOTE_LABEL   = "vote";
-const auto KEY_VOTE_SIZE        = strlen(KEY_VOTE_LABEL);
+constexpr auto KEY_VOTE_LABEL       = "vote";
+constexpr size_t KEY_VOTE_SIZE      = 4;
 
-constexpr auto KEY_VOTES_LABEL  = "votes";
-const auto KEY_VOTES_SIZE       = strlen(KEY_VOTES_LABEL);
+constexpr auto KEY_VOTES_LABEL      = "votes";
+constexpr size_t KEY_VOTES_SIZE     = 5;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add Vote Asset data to a Transaction Map.


### PR DESCRIPTION

## Summary

Per Codacy & CodeFactor

- use explicit size vs strlen for transaction labels (mapping, json).

This is a non-breaking change.

## Checklist

- [x] Ready to be merged
