### PR TITLE
ci: add sanitization checks

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,24 @@
+name: Sanitizers
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+  pull_request:
+    types: [ready_for_review, synchronize, opened]
+
+jobs:
+  asan:
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - run: COMPILER=clang++
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake -DUNIT_TEST=ON -DENABLE_SANITIZERS=ON ..
+          cmake --build .
+      - name: Run Sanitization Checks
+        run: ./build/test/ark_cpp_crypto_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,27 @@ endif()
 # ------------------------------------------------------------------------------
 
 # ------------------------------------------------------------------------------
+# ASAN
+# ------------------------------------------------------------------------------
+
+option(ENABLE_SANITIZERS "Enable Sanitization Checks" OFF)
+
+if(ENABLE_SANITIZERS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -fsanitize=address,undefined,float-divide-by-zero,unsigned-integer-overflow \
+        -fno-sanitize-recover=all \
+        -fno-optimize-sibling-calls \
+        -fsanitize-address-use-after-scope \
+        -fno-omit-frame-pointer \
+        -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/asan_blacklist.txt \
+        -g -O0"
+        CACHE STRING "Flags used by the compiler during AddressSanitizer builds."
+        FORCE)
+endif()
+
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 # Add the ARK C++ Crypto Library Subdirectory
 # ------------------------------------------------------------------------------
 

--- a/asan_blacklist.txt
+++ b/asan_blacklist.txt
@@ -1,0 +1,2 @@
+src:*/extern/*
+src:*/lib/*


### PR DESCRIPTION

## Summary

Add CI Sanitization checks.

Invoked at build with `cmake -DUNIT_TEST=ON -DENABLE_SANITIZERS=ON ..`

## Checklist

- [x] Ready to be merged
