### PR TITLE
ci(platformio): resolve esp8266 build issues

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -45,7 +45,7 @@ framework = arduino
 ##########
 ; ESP8266
 [esp8266]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+platform = https://github.com/platformio/platform-espressif8266.git
 board = huzzah
 build_flags = -D_GLIBCXX_USE_C99
 board_build.f_cpu = 160000000L


### PR DESCRIPTION

## Summary

staging branch no longer available for PlatformIO ESP8266:
`https://github.com/platformio/platform-espressif8266.git#feature/stage`

using new main branch for PlatformIO ESP8266:
`https://github.com/platformio/platform-espressif8266.git`

## Checklist

- [x] Ready to be merged
